### PR TITLE
el error de falta de padding en celu en header-flex se soluciona usan…

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -641,7 +641,7 @@ td {
     }
 
     .header-flex {
-        padding-inline: 15px;
+        padding: 0 15px;
     }
 
     .menu-but {


### PR DESCRIPTION
el error de falta de padding en celu en header-flex se soluciona usando padding comun en lugar de padding-inline. En algunos celus funciona, en otros no